### PR TITLE
Add analyzer and code fix for public types in Lucene.Net.Support, #1100

### DIFF
--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,2 @@
+roslyn_correctness.assembly_reference_validation = relaxed
+

--- a/.globalconfig
+++ b/.globalconfig
@@ -1,2 +1,0 @@
-roslyn_correctness.assembly_reference_validation = relaxed
-

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -21,5 +21,6 @@ _site/*
 release-build-outcomes\.svg
 release-workflow\.svg
 
-# Exclude markdown files
-.*\.md
+# Exclude analyzer releases markdown files
+AnalyzerReleases\..*\.md
+

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -20,3 +20,6 @@ _site/*
 
 release-build-outcomes\.svg
 release-workflow\.svg
+
+# Exclude markdown files
+.*\.md

--- a/docs/images/release-build-outcomes.md
+++ b/docs/images/release-build-outcomes.md
@@ -1,22 +1,3 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 This markup can be edited and converted to .svg or .png here:
 https://www.mermaidchart.com/app/projects/95759d78-db93-499c-ad66-0e3f698ba88c/diagrams/31dbd6bc-7ec8-4583-a456-55e3fe3f6cfc/version/v0.1/edit
 

--- a/docs/images/release-build-outcomes.md
+++ b/docs/images/release-build-outcomes.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 This markup can be edited and converted to .svg or .png here:
 https://www.mermaidchart.com/app/projects/95759d78-db93-499c-ad66-0e3f698ba88c/diagrams/31dbd6bc-7ec8-4583-a456-55e3fe3f6cfc/version/v0.1/edit
 

--- a/docs/images/release-workflow.md
+++ b/docs/images/release-workflow.md
@@ -1,22 +1,3 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 This markup can be edited and converted to .svg or .png here:
 https://www.mermaidchart.com/app/projects/95759d78-db93-499c-ad66-0e3f698ba88c/diagrams/35faa26e-5ccf-4433-962e-32f20496471c/version/v0.1/edit
 

--- a/docs/images/release-workflow.md
+++ b/docs/images/release-workflow.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 This markup can be edited and converted to .svg or .png here:
 https://www.mermaidchart.com/app/projects/95759d78-db93-499c-ad66-0e3f698ba88c/diagrams/35faa26e-5ccf-4433-962e-32f20496471c/version/v0.1/edit
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -282,8 +282,12 @@ Since Nerdbank.GitVersioning calculates the release version, the `AnalyzerReleas
 
 `AnalyzerReleases.Shipped.md` evolves by appending each release as a new section. Each release is marked with a `## Release <version>` header.
 
+> [!NOTE]
+> Due to a limitation/bug in the Roslyn meta-analyzers, the Release header cannot contain semver pre-release labels (e.g., `-beta`, `-rc`, etc.).
+> Therefore, the version token `{{vnext}}` is used to indicate the next release version, which will be replaced with the actual version during the release process.
+
 ```markdown
-## Release 2.0.0-alpha.1
+## Release 2.0.0
 
 ### New Rules
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -284,10 +284,10 @@ Since Nerdbank.GitVersioning calculates the release version, the `AnalyzerReleas
 
 > [!NOTE]
 > Due to a limitation/bug in the Roslyn meta-analyzers, the Release header cannot contain semver pre-release labels (e.g., `-beta`, `-rc`, etc.).
-> Therefore, the version token `{{vnext}}` is used to indicate the next release version, which will be replaced with the actual version during the release process.
+> Therefore, the version token `{{vnext}}` is used to indicate the next minor release version, which will be replaced with the actual version during the git post-commit hook.
 
 ```markdown
-## Release 2.0.0
+## Release 2.0
 
 ### New Rules
 

--- a/eng/git-hooks/post-commit
+++ b/eng/git-hooks/post-commit
@@ -56,8 +56,8 @@ fi
 # Set flag to prevent recursion
 export POST_COMMIT_RUNNING=1
 
-# Get the NuGet version
-version=$(nbgv get-version -v NuGetPackageVersion)
+# Get the NuGet version without any prerelease suffix, which is not compatible with the Roslyn meta-analyzers
+version=$(nbgv get-version -v Version)
 echo "Replacing '$token' with '$version' in '$file'"
 
 # Replace {{vnext}} only in lines starting with "## Release "

--- a/eng/git-hooks/post-commit
+++ b/eng/git-hooks/post-commit
@@ -45,10 +45,10 @@ The 'nbgv' tool is required but not installed.
 To recover manually:
 
 1. Install the nbgv tool (see the docs/make-release.md documentation)
-2. Run: nbgv get-version -v NuGetPackageVersion
+2. Run: nbgv get-version -v MajorMinorVersion
 3. In $file, replace the $token token with the version returned from step 2
 4. Run: git add $file && git commit --amend --no-edit
-5. Run: nbgv get-version -v NuGetPackageVersion again to ensure the version is the same as step 2 before proceeding
+5. Run: nbgv get-version -v MajorMinorVersion again to ensure the version is the same as step 2 before proceeding
 EOF
     exit 1
 fi
@@ -57,7 +57,7 @@ fi
 export POST_COMMIT_RUNNING=1
 
 # Get the NuGet version without any prerelease suffix, which is not compatible with the Roslyn meta-analyzers
-version=$(nbgv get-version -v Version)
+version=$(nbgv get-version -v MajorMinorVersion)
 echo "Replacing '$token' with '$version' in '$file'"
 
 # Replace {{vnext}} only in lines starting with "## Release "

--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/CodeFixResources.resx
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/CodeFixResources.resx
@@ -122,4 +122,7 @@ under the License.
     <value>Use {0}</value>
     <comment>Title for code fix; {0} is the code element to utilize.</comment>
   </data>
+  <data name="MakeXInternal" xml:space="preserve">
+    <value>Make {0} internal</value>
+  </data>
 </root>

--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
@@ -31,8 +31,8 @@ using SyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 
 namespace Lucene.Net.CodeAnalysis.Dev;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider)), Shared]
-public class LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider : CodeFixProvider
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider)), Shared]
+public class LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider : CodeFixProvider
 {
     // Specify the diagnostic IDs of analyzers that are expected to be linked.
     public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
@@ -79,7 +79,7 @@ public class LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider : CodeFi
         }
     }
 
-    private async Task<Solution> MakeDeclarationInternal(Document document,
+    private static async Task<Solution> MakeDeclarationInternal(Document document,
         MemberDeclarationSyntax memberDeclaration,
         CancellationToken cancellationToken)
     {

--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider.cs
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lucene.Net.CodeAnalysis.Dev.CodeFixes;
+using Lucene.Net.CodeAnalysis.Dev.CodeFixes.Utility;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using SyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
+
+namespace Lucene.Net.CodeAnalysis.Dev;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider)), Shared]
+public class LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider : CodeFixProvider
+{
+    // Specify the diagnostic IDs of analyzers that are expected to be linked.
+    public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } =
+        [Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.Id];
+
+    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        // We link only one diagnostic and assume there is only one diagnostic in the context.
+        var diagnostic = context.Diagnostics.Single();
+
+        // 'SourceSpan' of 'Location' is the highlighted area. We're going to use this area to find the 'SyntaxNode' to rename.
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Get the root of Syntax Tree that contains the highlighted diagnostic.
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        // Find SyntaxNode corresponding to the diagnostic.
+        var diagnosticNode = root?.FindNode(diagnosticSpan);
+
+        if (diagnosticNode is MemberDeclarationSyntax declaration)
+        {
+            var name = declaration switch
+            {
+                BaseTypeDeclarationSyntax baseTypeDeclaration => baseTypeDeclaration.Identifier.ToString(),
+                DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Identifier.ToString(),
+                _ => null
+            };
+
+            if (name == null)
+            {
+                return;
+            }
+
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeActionHelper.CreateFromResource(
+                    CodeFixResources.MakeXInternal,
+                    createChangedSolution: c => MakeDeclarationInternal(context.Document, declaration, c),
+                    "MakeDeclarationInternal",
+                    name),
+                diagnostic);
+        }
+    }
+
+    private async Task<Solution> MakeDeclarationInternal(Document document,
+        MemberDeclarationSyntax memberDeclaration,
+        CancellationToken cancellationToken)
+    {
+        var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (syntaxRoot == null) return document.Project.Solution;
+
+        // Remove existing accessibility modifiers
+        var newModifiers = SyntaxFactory.TokenList(
+                memberDeclaration.Modifiers
+                .Where(modifier => !modifier.IsKind(SyntaxKind.PrivateKeyword) &&
+                                   !modifier.IsKind(SyntaxKind.ProtectedKeyword) &&
+                                   !modifier.IsKind(SyntaxKind.InternalKeyword) &&
+                                   !modifier.IsKind(SyntaxKind.PublicKeyword))
+            ).Insert(0, SyntaxFactory.Token(SyntaxKind.InternalKeyword)); // Ensure 'internal' is the first modifier
+
+        var newMemberDeclaration = memberDeclaration.WithModifiers(newModifiers);
+        var newRoot = syntaxRoot.ReplaceNode(memberDeclaration, newMemberDeclaration);
+        return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/Utility/CodeActionHelper.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/Utility/CodeActionHelper.cs
@@ -37,5 +37,18 @@ namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes.Utility
             var title = string.Format(resourceValue, args);
             return CodeAction.Create(title, createChangedDocument, equivalenceKey);
         }
+
+        /// <summary>
+        /// Create a CodeAction using a resource string and formatting arguments.
+        /// </summary>
+        public static CodeAction CreateFromResource(
+            string resourceValue,
+            Func<CancellationToken, Task<Solution>> createChangedSolution,
+            string equivalenceKey,
+            params object[] args)
+        {
+            var title = string.Format(resourceValue, args);
+            return CodeAction.Create(title, createChangedSolution, equivalenceKey);
+        }
     }
 }

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/Lucene.Net.CodeAnalysis.Dev.Sample.csproj
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/Lucene.Net.CodeAnalysis.Dev.Sample.csproj
@@ -32,8 +32,8 @@ under the License.
     <_PackageVersionPropsFilePath>$(_NuGetPackageOutputPath)\Lucene.Net.CodeAnalysis.Dev.Version.props</_PackageVersionPropsFilePath>
     <!-- We install the analyzer package in a local directory so we don't pollute the
           .nuget cache on the dev machine with temporary builds -->
-    <RestorePackagesPath>obj\LocalNuGetPackages</RestorePackagesPath>
-    <_RestorePackagesPath>$(RestorePackagesPath)\lucene.net.codeanalsis.dev</_RestorePackagesPath>
+    <RestorePackagesPath>obj/LocalNuGetPackages</RestorePackagesPath>
+    <_RestorePackagesPath>$(RestorePackagesPath)/lucene.net.codeanalysis.dev</_RestorePackagesPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="Exists('$(_NuGetPackageOutputPath)')">

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_BlockScopedNamespace.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_BlockScopedNamespace.cs
@@ -1,0 +1,28 @@
+namespace Lucene.Net.Support.BlockScoped
+{
+    public class PublicClass
+    {
+    }
+
+    public interface PublicInterface
+    {
+    }
+
+    public enum PublicEnum
+    {
+    }
+
+    public delegate void PublicDelegate();
+
+    public struct PublicStruct
+    {
+    }
+
+    public record PublicRecord
+    {
+    }
+
+    public record struct PublicRecordStruct
+    {
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_BlockScopedNamespace.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_BlockScopedNamespace.cs
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 namespace Lucene.Net.Support.BlockScoped
 {
     public class PublicClass

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_FileScopedNamespace.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_FileScopedNamespace.cs
@@ -1,0 +1,27 @@
+namespace Lucene.Net.Support;
+
+public class PublicClass
+{
+}
+
+public interface PublicInterface
+{
+}
+
+public enum PublicEnum
+{
+}
+
+public delegate void PublicDelegate();
+
+public struct PublicStruct
+{
+}
+
+public record PublicRecord
+{
+}
+
+public record struct PublicRecordStruct
+{
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_FileScopedNamespace.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_FileScopedNamespace.cs
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 namespace Lucene.Net.Support;
 
 public class PublicClass

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_PartialClass1.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_PartialClass1.cs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Lucene.Net.Support.BlockScoped
+{
+    public partial class PublicPartialClass
+    {
+        public void Method1()
+        {
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_PartialClass2.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1005Sample_PartialClass2.cs
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Lucene.Net.Support.BlockScoped
+{
+    public partial class PublicPartialClass
+    {
+        public void Method2()
+        {
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 1.0.0
+## Release 1.0
 
 ### New Rules
 

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
@@ -1,30 +1,11 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 ## Release 1.0.0-alpha.6
 
 ### New Rules
 
- Rule ID       | Category | Severity | Notes
+ Rule ID       | Category | Severity | Notes                                                                                                                                                     
 ---------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
- LuceneDev1000 | Design   | Warning  | Floating point types should not be compared for exact equality
- LuceneDev1001 | Design   | Warning  | Floating point types should be formatted with J2N methods
- LuceneDev1002 | Design   | Warning  | Floating point type arithmetic needs to be checked
- LuceneDev1003 | Design   | Warning  | Method parameters that accept array types should be analyzed to determine whether they are better suited to be ref or out parameters
- LuceneDev1004 | Design   | Warning  | Methods that return array types should be analyzed to determine whether they are better suited to be one or more out parameters or to return a ValueTuple
+ LuceneDev1000 | Design   | Warning  | Floating point types should not be compared for exact equality                                                                                            
+ LuceneDev1001 | Design   | Warning  | Floating point types should be formatted with J2N methods                                                                                                 
+ LuceneDev1002 | Design   | Warning  | Floating point type arithmetic needs to be checked                                                                                                        
+ LuceneDev1003 | Design   | Warning  | Method parameters that accept array types should be analyzed to determine whether they are better suited to be ref or out parameters                      
+ LuceneDev1004 | Design   | Warning  | Methods that return array types should be analyzed to determine whether they are better suited to be one or more out parameters or to return a ValueTuple 

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
@@ -1,11 +1,30 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 ## Release 1.0.0-alpha.6
 
 ### New Rules
 
- Rule ID       | Category | Severity | Notes                                                                                                                                                     
+ Rule ID       | Category | Severity | Notes
 ---------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
- LuceneDev1000 | Design   | Warning  | Floating point types should not be compared for exact equality                                                                                            
- LuceneDev1001 | Design   | Warning  | Floating point types should be formatted with J2N methods                                                                                                 
- LuceneDev1002 | Design   | Warning  | Floating point type arithmetic needs to be checked                                                                                                        
- LuceneDev1003 | Design   | Warning  | Method parameters that accept array types should be analyzed to determine whether they are better suited to be ref or out parameters                      
- LuceneDev1004 | Design   | Warning  | Methods that return array types should be analyzed to determine whether they are better suited to be one or more out parameters or to return a ValueTuple 
+ LuceneDev1000 | Design   | Warning  | Floating point types should not be compared for exact equality
+ LuceneDev1001 | Design   | Warning  | Floating point types should be formatted with J2N methods
+ LuceneDev1002 | Design   | Warning  | Floating point type arithmetic needs to be checked
+ LuceneDev1003 | Design   | Warning  | Method parameters that accept array types should be analyzed to determine whether they are better suited to be ref or out parameters
+ LuceneDev1004 | Design   | Warning  | Methods that return array types should be analyzed to determine whether they are better suited to be one or more out parameters or to return a ValueTuple

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 1.0.0-alpha.6
+## Release 1.0.0
 
 ### New Rules
 

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,4 +1,5 @@
 ### New Rules
 
- Rule ID       | Category | Severity | Notes                                                                                                                                                     
+ Rule ID       | Category | Severity | Notes
 ---------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ LuceneDev1005 | Design   | Warning  | Types in the Lucene.Net.Support namespace should not be public

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,22 +1,3 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 ### New Rules
 
  Rule ID       | Category | Severity | Notes

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,3 +1,22 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
 ### New Rules
 
  Rule ID       | Category | Severity | Notes

--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev1xxx/LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer.cs
@@ -1,0 +1,81 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using System.Collections.Immutable;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+
+namespace Lucene.Net.CodeAnalysis.Dev
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes];
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeSyntax,
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.EnumDeclaration,
+                SyntaxKind.InterfaceDeclaration,
+                SyntaxKind.RecordDeclaration,
+                SyntaxKind.StructDeclaration,
+                SyntaxKind.RecordStructDeclaration,
+                SyntaxKind.DelegateDeclaration);
+        }
+
+        private static void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
+        {
+            // any public types in the Lucene.Net.Support (or child) namespace should raise the diagnostic
+            if (context.Node.Parent is not BaseNamespaceDeclarationSyntax namespaceDeclarationSyntax
+                || !namespaceDeclarationSyntax.Name.ToString().StartsWith("Lucene.Net.Support"))
+            {
+                return;
+            }
+
+            if (context.Node is DelegateDeclarationSyntax delegateDeclarationSyntax
+                && delegateDeclarationSyntax.Modifiers.Any(SyntaxKind.PublicKeyword))
+            {
+                const string typeKind = "Delegate";
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes, delegateDeclarationSyntax.GetLocation(), typeKind, delegateDeclarationSyntax.Identifier.ToString()));
+            }
+            else if (context.Node is BaseTypeDeclarationSyntax baseTypeDeclarationSyntax
+                     && baseTypeDeclarationSyntax.Modifiers.Any(SyntaxKind.PublicKeyword))
+            {
+                var typeKind = context.Node switch
+                {
+                    ClassDeclarationSyntax => "Class",
+                    EnumDeclarationSyntax => "Enum",
+                    InterfaceDeclarationSyntax => "Interface",
+                    RecordDeclarationSyntax record when record.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword) => "Record struct",
+                    RecordDeclarationSyntax => "Record",
+                    StructDeclarationSyntax => "Struct",
+                    _ => "Type", // should not happen
+                };
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes, baseTypeDeclarationSyntax.GetLocation(), typeKind, baseTypeDeclarationSyntax.Identifier.ToString()));
+            }
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
@@ -206,7 +206,4 @@ under the License.
   <data name="LuceneDev1005_AnalyzerMessageFormat" xml:space="preserve">
     <value>{0} '{1}' should not have public accessibility in the Support namespace</value>
   </data>
-  <data name="LuceneDev1005_CodeFixTitle" xml:space="preserve">
-    <value>Make {0} internal</value>
-  </data>
 </root>

--- a/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
@@ -197,4 +197,16 @@ under the License.
     <value>Methods that return array types should be analyzed to determine whether they are better suited to be one or more out parameters or to return a ValueTuple</value>
     <comment>The title of the diagnostic.</comment>
   </data>
+  <data name="LuceneDev1005_AnalyzerTitle" xml:space="preserve">
+    <value>Types in the Support namespace should not be public</value>
+  </data>
+  <data name="LuceneDev1005_AnalyzerDescription" xml:space="preserve">
+    <value>Types in the Lucene.Net.Support namespace should not be public.</value>
+  </data>
+  <data name="LuceneDev1005_AnalyzerMessageFormat" xml:space="preserve">
+    <value>{0} '{1}' should not have public accessibility in the Support namespace</value>
+  </data>
+  <data name="LuceneDev1005_CodeFixTitle" xml:space="preserve">
+    <value>Make {0} internal</value>
+  </data>
 </root>

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/Category.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/Category.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -16,10 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Lucene.Net.CodeAnalysis.Dev.Utility
 {

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev1xxx.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev1xxx.cs
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -60,6 +60,13 @@ namespace Lucene.Net.CodeAnalysis.Dev.Utility
         public static readonly DiagnosticDescriptor LuceneDev1004_ArrayMethodReturnValue =
             Diagnostic(
                 "LuceneDev1004",
+                Design,
+                Warning
+            );
+
+        public static readonly DiagnosticDescriptor LuceneDev1005_LuceneNetSupportPublicTypes =
+            Diagnostic(
+                "LuceneDev1005",
                 Design,
                 Warning
             );

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
@@ -104,4 +104,152 @@ public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider
 
         await test.RunAsync();
     }
+
+    [Test]
+    public async Task PublicPartialClassInSupport_FileScopedNamespace_MakeInternalFix()
+    {
+        const string testCode1 =
+            """
+            namespace Lucene.Net.Support;
+
+            public partial class MyPartialClass
+            {
+                public void Method1() { }
+            }
+            """;
+
+        const string testCode2 =
+            """
+            namespace Lucene.Net.Support;
+
+            public partial class MyPartialClass
+            {
+                public void Method2() { }
+            }
+            """;
+
+        const string fixedCode1 =
+            """
+            namespace Lucene.Net.Support;
+
+            internal partial class MyPartialClass
+            {
+                public void Method1() { }
+            }
+            """;
+
+        const string fixedCode2 =
+            """
+            namespace Lucene.Net.Support;
+
+            internal partial class MyPartialClass
+            {
+                public void Method2() { }
+            }
+            """;
+
+        var expected1 = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyPartialClass")
+            .WithLocation("/0/Test0.cs", line: 3, column: 1);
+
+        var expected2 = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyPartialClass")
+            .WithLocation("/0/Test1.cs", line: 3, column: 1);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
+        {
+            ExpectedDiagnostics = { expected1, expected2 },
+            // Skip FixAll to test single fix application only
+            CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne
+        };
+
+        test.TestState.Sources.Add(testCode1.ReplaceLineEndings());
+        test.TestState.Sources.Add(testCode2.ReplaceLineEndings());
+        test.FixedState.Sources.Add(fixedCode1.ReplaceLineEndings());
+        test.FixedState.Sources.Add(fixedCode2.ReplaceLineEndings());
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task PublicPartialClassInSupport_BlockScopedNamespace_MakeInternalFix()
+    {
+        const string testCode1 =
+            """
+            namespace Lucene.Net.Support
+            {
+                public partial class MyPartialClass
+                {
+                    public void Method1() { }
+                }
+            }
+            """;
+
+        const string testCode2 =
+            """
+            namespace Lucene.Net.Support
+            {
+                public partial class MyPartialClass
+                {
+                    public void Method2() { }
+                }
+            }
+            """;
+
+        const string fixedCode1 =
+            """
+            namespace Lucene.Net.Support
+            {
+                internal partial class MyPartialClass
+                {
+                    public void Method1() { }
+                }
+            }
+            """;
+
+        const string fixedCode2 =
+            """
+            namespace Lucene.Net.Support
+            {
+                internal partial class MyPartialClass
+                {
+                    public void Method2() { }
+                }
+            }
+            """;
+
+        var expected1 = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyPartialClass")
+            .WithLocation("/0/Test0.cs", line: 3, column: 5);
+
+        var expected2 = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyPartialClass")
+            .WithLocation("/0/Test1.cs", line: 3, column: 5);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
+        {
+            ExpectedDiagnostics = { expected1, expected2 },
+            // Skip FixAll to test single fix application only
+            CodeFixTestBehaviors = CodeFixTestBehaviors.FixOne
+        };
+
+        test.TestState.Sources.Add(testCode1.ReplaceLineEndings());
+        test.TestState.Sources.Add(testCode2.ReplaceLineEndings());
+        test.FixedState.Sources.Add(fixedCode1.ReplaceLineEndings());
+        test.FixedState.Sources.Add(fixedCode2.ReplaceLineEndings());
+
+        await test.RunAsync();
+    }
 }

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.CodeAnalysis.Dev.TestUtilities;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes;
+
+public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider
+{
+    [Test]
+    public async Task PublicTypeInSupport_FileScopedNamespace_MakeInternalFix()
+    {
+        const string testCode =
+            """
+            namespace Lucene.Net.Support;
+
+            public class MyClass
+            {
+            }
+            """;
+
+        const string fixedCode =
+            """
+            namespace Lucene.Net.Support;
+
+            internal class MyClass
+            {
+            }
+            """;
+
+        var expected = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyClass")
+            .WithLocation(3, 1);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider())
+        {
+            TestCode = testCode.ReplaceLineEndings(),
+            FixedCode = fixedCode.ReplaceLineEndings(),
+            ExpectedDiagnostics = { expected }
+        };
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task PublicTypeInSupport_BlockScopedNamespace_MakeInternalFix()
+    {
+        const string testCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                public class MyClass
+                {
+                }
+            }
+            """;
+
+        const string fixedCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                internal class MyClass
+                {
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyClass")
+            .WithLocation(3, 5);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider())
+        {
+            TestCode = testCode.ReplaceLineEndings(),
+            FixedCode = fixedCode.ReplaceLineEndings(),
+            ExpectedDiagnostics = { expected }
+        };
+
+        await test.RunAsync();
+    }
+}

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
@@ -54,7 +54,7 @@ public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider
 
         var test = new InjectableCodeFixTest(
             () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
-            () => new LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider())
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
         {
             TestCode = testCode.ReplaceLineEndings(),
             FixedCode = fixedCode.ReplaceLineEndings(),
@@ -95,7 +95,7 @@ public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider
 
         var test = new InjectableCodeFixTest(
             () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
-            () => new LuceneDev1005_LuceneNetSupportPublicTypesCsCodeFixProvider())
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
         {
             TestCode = testCode.ReplaceLineEndings(),
             FixedCode = fixedCode.ReplaceLineEndings(),

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider.cs
@@ -252,4 +252,193 @@ public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider
 
         await test.RunAsync();
     }
+
+    [Test]
+    public async Task PublicTypeInSupport_WithLicenseHeader_PreservesHeader()
+    {
+        const string testCode =
+            """
+            /*
+             * Licensed to the Apache Software Foundation (ASF) under one or more
+             * contributor license agreements.  See the NOTICE file distributed with
+             * this work for additional information regarding copyright ownership.
+             * The ASF licenses this file to You under the Apache License, Version 2.0
+             * (the "License"); you may not use this file except in compliance with
+             * the License.  You may obtain a copy of the License at
+             *
+             *     http://www.apache.org/licenses/LICENSE-2.0
+             *
+             * Unless required by applicable law or agreed to in writing, software
+             * distributed under the License is distributed on an "AS IS" BASIS,
+             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+             * See the License for the specific language governing permissions and
+             * limitations under the License.
+             */
+
+            namespace Lucene.Net.Support;
+
+            public class MyClass
+            {
+            }
+            """;
+
+        const string fixedCode =
+            """
+            /*
+             * Licensed to the Apache Software Foundation (ASF) under one or more
+             * contributor license agreements.  See the NOTICE file distributed with
+             * this work for additional information regarding copyright ownership.
+             * The ASF licenses this file to You under the Apache License, Version 2.0
+             * (the "License"); you may not use this file except in compliance with
+             * the License.  You may obtain a copy of the License at
+             *
+             *     http://www.apache.org/licenses/LICENSE-2.0
+             *
+             * Unless required by applicable law or agreed to in writing, software
+             * distributed under the License is distributed on an "AS IS" BASIS,
+             * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+             * See the License for the specific language governing permissions and
+             * limitations under the License.
+             */
+
+            namespace Lucene.Net.Support;
+
+            internal class MyClass
+            {
+            }
+            """;
+
+        var expected = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyClass")
+            .WithLocation(20, 1);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
+        {
+            TestCode = testCode.ReplaceLineEndings(),
+            FixedCode = fixedCode.ReplaceLineEndings(),
+            ExpectedDiagnostics = { expected }
+        };
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task PublicTypeInSupport_WithLicenseHeaderInsideNamespace_PreservesHeader()
+    {
+        const string testCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                /*
+                 * Licensed to the Apache Software Foundation (ASF) under one or more
+                 * contributor license agreements.  See the NOTICE file distributed with
+                 * this work for additional information regarding copyright ownership.
+                 * The ASF licenses this file to You under the Apache License, Version 2.0
+                 * (the "License"); you may not use this file except in compliance with
+                 * the License.  You may obtain a copy of the License at
+                 *
+                 *     http://www.apache.org/licenses/LICENSE-2.0
+                 *
+                 * Unless required by applicable law or agreed to in writing, software
+                 * distributed under the License is distributed on an "AS IS" BASIS,
+                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                 * See the License for the specific language governing permissions and
+                 * limitations under the License.
+                 */
+
+                public class MyClass
+                {
+                }
+            }
+            """;
+
+        const string fixedCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                /*
+                 * Licensed to the Apache Software Foundation (ASF) under one or more
+                 * contributor license agreements.  See the NOTICE file distributed with
+                 * this work for additional information regarding copyright ownership.
+                 * The ASF licenses this file to You under the Apache License, Version 2.0
+                 * (the "License"); you may not use this file except in compliance with
+                 * the License.  You may obtain a copy of the License at
+                 *
+                 *     http://www.apache.org/licenses/LICENSE-2.0
+                 *
+                 * Unless required by applicable law or agreed to in writing, software
+                 * distributed under the License is distributed on an "AS IS" BASIS,
+                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                 * See the License for the specific language governing permissions and
+                 * limitations under the License.
+                 */
+
+                internal class MyClass
+                {
+                }
+            }
+            """;
+
+        var expected = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyClass")
+            .WithLocation(20, 5);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
+        {
+            TestCode = testCode.ReplaceLineEndings(),
+            FixedCode = fixedCode.ReplaceLineEndings(),
+            ExpectedDiagnostics = { expected }
+        };
+
+        await test.RunAsync();
+    }
+
+    [Test]
+    public async Task PublicTypeInSupport_WithTrailingTrivia_PreservesTrailingTrivia()
+    {
+        const string testCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                public class MyClass
+                {
+                } // Important trailing comment
+            }
+            """;
+
+        const string fixedCode =
+            """
+            namespace Lucene.Net.Support
+            {
+                internal class MyClass
+                {
+                } // Important trailing comment
+            }
+            """;
+
+        var expected = new DiagnosticResult(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes)
+            .WithSeverity(DiagnosticSeverity.Warning)
+            .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+            .WithArguments("Class", "MyClass")
+            .WithLocation(3, 5);
+
+        var test = new InjectableCodeFixTest(
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer(),
+            () => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeFixProvider())
+        {
+            TestCode = testCode.ReplaceLineEndings(),
+            FixedCode = fixedCode.ReplaceLineEndings(),
+            ExpectedDiagnostics = { expected }
+        };
+
+        await test.RunAsync();
+    }
 }

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev1xxx/TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer.cs
@@ -1,0 +1,336 @@
+﻿/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Threading.Tasks;
+using Lucene.Net.CodeAnalysis.Dev.TestUtilities;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Lucene.Net.CodeAnalysis.Dev
+{
+    public class TestLuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer
+    {
+        //No diagnostics expected to show up
+        [Test]
+        public async Task TestEmptyFile()
+        {
+            const string testCode = "";
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_FileScopedNamespace_PositiveTest(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $"""
+                namespace Lucene.Net.Support;
+                public {typeKind} {typeName};
+                """;
+
+            var expected = DiagnosticResult.CompilerWarning(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.Id)
+                .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+                .WithArguments(typeKindDesc, typeName)
+                .WithLocation(2, 1);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_FileScopedNamespace_NegativeTest_PublicInAnotherNamespace(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $"""
+                 namespace Lucene.Net.SomethingElse;
+                 public {typeKind} {typeName};
+                 """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_FileScopedNamespace_NegativeTest_NonPublicInSupport(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $"""
+                 namespace Lucene.Net.Support.Bar;
+                 internal {typeKind} {typeName};
+                 """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_FileScopedNamespace_Delegate_PositiveTest()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.Support;
+                public delegate void PublicDelegate();
+                """;
+
+            var expected = DiagnosticResult.CompilerWarning(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.Id)
+                .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+                .WithArguments("Delegate", "PublicDelegate")
+                .WithLocation(2, 1);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_FileScopedNamespace_Delegate_NegativeTest_PublicInAnotherNamespace()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.SomethingElse;
+                public delegate void PublicDelegate();
+                """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_FileScopedNamespace_Delegate_NegativeTest_NonPublicInSupport()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.Support;
+                internal delegate void PublicDelegate();
+                """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_BlockScopedNamespace_PositiveTest(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $$"""
+                namespace Lucene.Net.Support
+                {
+                    public {{typeKind}} {{typeName}};
+                }
+                """;
+
+            var expected = DiagnosticResult.CompilerWarning(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.Id)
+                .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+                .WithArguments(typeKindDesc, typeName)
+                .WithLocation(3, 5);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_BlockScopedNamespace_NegativeTest_PublicInAnotherNamespace(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $$"""
+                namespace Lucene.Net.SomethingElse
+                {
+                    public {{typeKind}} {{typeName}};
+                }
+                """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        [TestCase("class")]
+        [TestCase("struct")]
+        [TestCase("interface")]
+        [TestCase("record")]
+        [TestCase("record struct")]
+        [TestCase("enum")]
+        public async Task TestDiagnostic_BlockScopedNamespace_NegativeTest_NonPublicInSupport(string typeKind)
+        {
+            string typeKindDesc = typeKind[0].ToString().ToUpper() + typeKind[1..];
+            string typeName = $"Public{typeKindDesc.Replace(" ", "")}";
+
+            string testCode =
+                $$"""
+                  namespace Lucene.Net.Support.Foo
+                  {
+                      internal {{typeKind}} {{typeName}};
+                  }
+                  """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_BlockScopedNamespace_Delegate_PositiveTest()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.Support
+                {
+                    public delegate void PublicDelegate();
+                }
+                """;
+
+            var expected = DiagnosticResult.CompilerWarning(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.Id)
+                .WithMessageFormat(Descriptors.LuceneDev1005_LuceneNetSupportPublicTypes.MessageFormat)
+                .WithArguments("Delegate", "PublicDelegate")
+                .WithLocation(3, 5);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_BlockScopedNamespace_Delegate_NegativeTest_PublicInAnotherNamespace()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.SomethingElse
+                {
+                    public delegate void PublicDelegate();
+                }
+                """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestDiagnostic_BlockScopedNamespace_Delegate_NegativeTest_NonPublicInSupport()
+        {
+            const string testCode =
+                """
+                namespace Lucene.Net.Support
+                {
+                    internal delegate void PublicDelegate();
+                }
+                """;
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1005_LuceneNetSupportPublicTypesCSCodeAnalyzer())
+            {
+                TestCode = testCode
+            };
+
+            await test.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
NOTE: This requires #1 to be merged first, as it is a stacked PR on top of that one, so it shows all changes from that PR as well. I will rebase it against main once #1 is merged.

This adds a diagnostic and code fix for detecting public types in the Lucene.Net.Support namespace. 

Partial https://github.com/apache/lucenenet/issues/1100 (Will still need to add these analyzers to Lucene.NET in order to close that issue)