### PR TITLE
Reserve LuceneDev6001-6003 and add initial entries for string/span/char analyzer rules

### DIFF
--- a/DiagnosticCategoryAndIdRanges.txt
+++ b/DiagnosticCategoryAndIdRanges.txt
@@ -11,16 +11,16 @@
 #   4. Your rule ID is now reserved and can be used in your PR.
 #
 # In the event of conflict in step 3, make sure you discard your changes, pull latest, and try again.
-# DO NOT remove ID ranges already defined or merge this file in git.  
+# DO NOT remove ID ranges already defined or merge this file in git.
 #
 Design: LuceneDev1000-LuceneDev1008
 Globalization:
 Mobility:
 Performance:
 Security:
-Usage: LuceneDev6000
+Usage: LuceneDev6000-LuceneDev6003
 Naming:
 Interoperability:
-Maintainability: 
+Maintainability:
 Reliability:
 Documentation:

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,10 +1,10 @@
 ### New Rules
 
-| Rule ID       | Category | Severity | Notes                                                                                                                                           |
-| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)     |
-| LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value) |
-| LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value                                         |
-| LuceneDev6001 | Usage    | Error    | String overloads of StartsWith/EndsWith/IndexOf/LastIndexOf must be called with StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase  |
-| LuceneDev6002 | Usage    | Warning  | Span overloads of StartsWith/EndsWith/IndexOf/LastIndexOf should not pass non-Ordinal StringComparison                                          |
-| LuceneDev6003 | Usage    | Info     | Single-character string arguments should use the char overload of StartsWith/EndsWith/IndexOf/LastIndexOf instead of a string                   |
+ Rule ID       | Category | Severity | Notes
+---------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)
+ LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value)
+ LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value
+ LuceneDev6001 | Usage    | Error    | String overloads of StartsWith/EndsWith/IndexOf/LastIndexOf must be called with StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase
+ LuceneDev6002 | Usage    | Warning  | Span overloads of StartsWith/EndsWith/IndexOf/LastIndexOf should not pass non-Ordinal StringComparison
+ LuceneDev6003 | Usage    | Info     | Single-character string arguments should use the char overload of StartsWith/EndsWith/IndexOf/LastIndexOf instead of a string

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,7 +1,10 @@
 ### New Rules
 
- Rule ID       | Category | Severity | Notes
----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
- LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)
- LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value)
- LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value
+| Rule ID       | Category | Severity | Notes                                                                                                                                           |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)     |
+| LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value) |
+| LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value                                         |
+| LuceneDev6001 | Usage    | Error    | String overloads of StartsWith/EndsWith/IndexOf/LastIndexOf must be called with StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase  |
+| LuceneDev6002 | Usage    | Warning  | Span overloads of StartsWith/EndsWith/IndexOf/LastIndexOf should not pass non-Ordinal StringComparison                                          |
+| LuceneDev6003 | Usage    | Info     | Single-character string arguments should use the char overload of StartsWith/EndsWith/IndexOf/LastIndexOf instead of a string                   |

--- a/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
+++ b/src/Lucene.Net.CodeAnalysis.Dev/AnalyzerReleases.Unshipped.md
@@ -1,10 +1,10 @@
 ### New Rules
 
- Rule ID       | Category | Severity | Notes
----------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
- LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)
- LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value)
- LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value
- LuceneDev6001 | Usage    | Error    | String overloads of StartsWith/EndsWith/IndexOf/LastIndexOf must be called with StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase
- LuceneDev6002 | Usage    | Warning  | Span overloads of StartsWith/EndsWith/IndexOf/LastIndexOf should not pass non-Ordinal StringComparison
- LuceneDev6003 | Usage    | Info     | Single-character string arguments should use the char overload of StartsWith/EndsWith/IndexOf/LastIndexOf instead of a string
+Rule ID       | Category | Severity | Notes
+--------------|----------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------
+LuceneDev1007 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (value type value)
+LuceneDev1008 | Design   | Warning  | Generic Dictionary<TKey, TValue> indexer should not be used to retrieve values because it may throw KeyNotFoundException (reference type value)
+LuceneDev6000 | Usage    | Info     | IDictionary indexer may be used to retrieve values, but must be checked for null before using the value
+LuceneDev6001 | Usage    | Error    | String overloads of StartsWith/EndsWith/IndexOf/LastIndexOf must be called with StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase
+LuceneDev6002 | Usage    | Warning  | Span overloads of StartsWith/EndsWith/IndexOf/LastIndexOf should not pass non-Ordinal StringComparison
+LuceneDev6003 | Usage    | Info     | Single-character string arguments should use the char overload of StartsWith/EndsWith/IndexOf/LastIndexOf instead of a string


### PR DESCRIPTION
This PR reserves diagnostic IDs 6001-6003 and adds corresponding entries in AnalyzerReleases.Unshipped.md for the new analyzers:

- LuceneDev6001: String overloads must use StringComparison.Ordinal or OrdinalIgnoreCase (Error)
- LuceneDev6002: Span overloads should not pass non-Ordinal StringComparison (Warning)
- LuceneDev6003: Single-character string arguments should use char overload (Info)

These changes are in preparation for implementing the analyzers in the next PR.
