### PR TITLE
Update GitHub macOS x64 runner to macos-15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        # macos-13 is specifically for running x64, macos-latest for arm64
-        os: [windows-latest, ubuntu-latest, macos-13, macos-latest]
+        # macos-15-intel is specifically for running x64, macos-latest for arm64
+        # NOTE: macos-15-intel will be discontinued in fall 2027
+        os: [windows-latest, ubuntu-latest, macos-15-intel, macos-latest]
         arch: [x64, arm64]
         tfm: [net8.0]
         exclude:
         - arch: arm64
-          os: macos-13
+          os: macos-15-intel
         - arch: arm64
           os: windows-latest
         - arch: arm64


### PR DESCRIPTION
The [macOS 13 image is discontinued](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/), so this updates to the `macos-15-intel` image. 

Note that this is the last in the line for x64 images for macOS, and this one will be discontinued in fall 2027. At that point we can switch to arm64-only macOS runs.