### PR TITLE
Implement LuceneDev1007, 1008, 6000 Analyzers & CodeFix with Unit Tests

### DIFF
--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes.LuceneDev1xxx
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LuceneDev1007_1008_DictionaryIndexerCodeFixProvider)), Shared]
+    public sealed class LuceneDev1007_1008_DictionaryIndexerCodeFixProvider : CodeFixProvider
+    {
+        private const string TitleReturn = "Use TryGetValue and return default on missing key";
+
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(
+                Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType.Id,
+                Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType.Id);
+
+        public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            if (root == null) return;
+
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                var elementAccess = root.FindToken(diagnostic.Location.SourceSpan.Start)
+                                        .Parent?
+                                        .AncestorsAndSelf()
+                                        .OfType<ElementAccessExpressionSyntax>()
+                                        .FirstOrDefault(e => e.Span.Contains(diagnostic.Location.SourceSpan));
+                if (elementAccess == null)
+                    continue;
+
+                // Only handle the "return dict[key];" pattern automatically.
+                if (elementAccess.Parent is not ReturnStatementSyntax returnStmt
+                    || returnStmt.Expression != elementAccess)
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        title: TitleReturn,
+                        createChangedDocument: c => ConvertReturnAsync(context.Document, returnStmt, elementAccess, c),
+                        equivalenceKey: TitleReturn),
+                    diagnostic);
+            }
+        }
+
+        private static async Task<Document> ConvertReturnAsync(
+            Document document,
+            ReturnStatementSyntax returnStmt,
+            ElementAccessExpressionSyntax elementAccess,
+            CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root == null) return document;
+
+            var receiver = elementAccess.Expression;
+            var keyArg = elementAccess.ArgumentList.Arguments.FirstOrDefault();
+            if (keyArg == null) return document;
+
+            var outName = PickLocalName(returnStmt);
+
+            // receiver.TryGetValue(key, out var <outName>)
+            var tryGetValueInvocation = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    receiver.WithoutTrivia(),
+                    SyntaxFactory.IdentifierName("TryGetValue")),
+                SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+                {
+                    keyArg.WithoutTrivia(),
+                    SyntaxFactory.Argument(
+                        SyntaxFactory.DeclarationExpression(
+                            SyntaxFactory.IdentifierName(
+                                SyntaxFactory.Identifier("var")),
+                            SyntaxFactory.SingleVariableDesignation(SyntaxFactory.Identifier(outName))))
+                        .WithRefOrOutKeyword(SyntaxFactory.Token(SyntaxKind.OutKeyword))
+                })));
+
+            // tryGetValueInvocation ? <outName> : default
+            var ternary = SyntaxFactory.ConditionalExpression(
+                tryGetValueInvocation,
+                SyntaxFactory.IdentifierName(outName),
+                SyntaxFactory.LiteralExpression(SyntaxKind.DefaultLiteralExpression,
+                    SyntaxFactory.Token(SyntaxKind.DefaultKeyword)));
+
+            var newReturn = returnStmt.WithExpression(ternary).WithAdditionalAnnotations(Formatter.Annotation);
+
+            var newRoot = root.ReplaceNode(returnStmt, newReturn);
+            return document.WithSyntaxRoot(newRoot);
+        }
+
+        private static string PickLocalName(SyntaxNode context)
+        {
+            // Avoid collisions with identifiers in the enclosing member.
+            var member = context.AncestorsAndSelf().OfType<MemberDeclarationSyntax>().FirstOrDefault();
+            var names = member == null
+                ? ImmutableHashSet<string>.Empty
+                : member.DescendantTokens()
+                        .Where(t => t.IsKind(SyntaxKind.IdentifierToken))
+                        .Select(t => t.ValueText)
+                        .ToImmutableHashSet();
+
+            if (!names.Contains("value"))
+                return "value";
+            for (int i = 1; i < 100; i++)
+            {
+                var candidate = "value" + i;
+                if (!names.Contains(candidate))
+                    return candidate;
+            }
+            return "value";
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.CodeFixes/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
@@ -49,6 +49,9 @@ namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes.LuceneDev1xxx
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             if (root == null) return;
 
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+            if (semanticModel == null) return;
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 var elementAccess = root.FindToken(diagnostic.Location.SourceSpan.Start)
@@ -66,6 +69,11 @@ namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes.LuceneDev1xxx
                     continue;
                 }
 
+                // If the receiver type doesn't expose an accessible TryGetValue method
+                // (e.g. only via explicit interface implementation), skip — the rewrite would not compile.
+                if (!HasAccessibleTryGetValue(semanticModel, elementAccess))
+                    continue;
+
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         title: TitleReturn,
@@ -73,6 +81,30 @@ namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes.LuceneDev1xxx
                         equivalenceKey: TitleReturn),
                     diagnostic);
             }
+        }
+
+        private static bool HasAccessibleTryGetValue(SemanticModel semanticModel, ElementAccessExpressionSyntax elementAccess)
+        {
+            var receiverType = semanticModel.GetTypeInfo(elementAccess.Expression).Type;
+            if (receiverType == null)
+                return false;
+
+            foreach (var member in receiverType.GetMembers("TryGetValue"))
+            {
+                if (member is not IMethodSymbol method)
+                    continue;
+                if (method.IsStatic)
+                    continue;
+                if (method.DeclaredAccessibility != Accessibility.Public)
+                    continue;
+                if (method.Parameters.Length != 2)
+                    continue;
+                if (method.Parameters[1].RefKind != RefKind.Out)
+                    continue;
+                return true;
+            }
+
+            return false;
         }
 
         private static async Task<Document> ConvertReturnAsync(

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerSample.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerSample.cs
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace Lucene.Net.CodeAnalysis.Dev.Sample.LuceneDev1xxx;
+
+public class LuceneDev1007_1008_DictionaryIndexerSample
+{
+    public int GetIntValue(IDictionary<string, int> dict, string key)
+    {
+        // LuceneDev1007 (value-type value): indexer may throw KeyNotFoundException.
+        return dict[key];
+    }
+
+    public string GetStringValue(IDictionary<string, string> dict, string key)
+    {
+        // LuceneDev1008 (reference-type value): indexer may throw KeyNotFoundException.
+        return dict[key];
+    }
+
+    public void ReadOnlyUsage(IReadOnlyDictionary<string, string> dict, string key)
+    {
+        // LuceneDev1008: also applies to IReadOnlyDictionary<TKey, TValue>.
+        var value = dict[key];
+    }
+
+    public void ConcreteDictionaryUsage(Dictionary<string, string> dict, string key)
+    {
+        // LuceneDev1008: Dictionary<TKey, TValue> implements IDictionary<TKey, TValue>.
+        var value = dict[key];
+    }
+
+    public void AssignmentIsFine(Dictionary<string, int> dict, string key)
+    {
+        // No diagnostic: indexer setter does not throw.
+        dict[key] = 42;
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev6xxx/LuceneDev6000_NonGenericDictionaryIndexerSample.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev.Sample/LuceneDev6xxx/LuceneDev6000_NonGenericDictionaryIndexerSample.cs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections;
+
+namespace Lucene.Net.CodeAnalysis.Dev.Sample.LuceneDev6xxx;
+
+public class LuceneDev6000_NonGenericDictionaryIndexerSample
+{
+    public object? GetValue(IDictionary dict, object key)
+    {
+        // LuceneDev6000 (Info): non-generic IDictionary indexer may return null for missing keys.
+        return dict[key];
+    }
+
+    public object? GetValueFromHashtable(Hashtable table, object key)
+    {
+        // LuceneDev6000: Hashtable implements non-generic IDictionary.
+        return table[key];
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev1xxx/LuceneDev1007_1008_DictionaryIndexerAnalyzer.cs
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Immutable;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev1xxx
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class LuceneDev1007_1008_DictionaryIndexerAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(
+                Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType,
+                Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeElementAccess, SyntaxKind.ElementAccessExpression);
+        }
+
+        private static void AnalyzeElementAccess(SyntaxNodeAnalysisContext ctx)
+        {
+            var elementAccess = (ElementAccessExpressionSyntax)ctx.Node;
+
+            // Skip assignment targets (setter usage does not throw).
+            if (IsAssignmentTarget(elementAccess))
+                return;
+
+            var symbolInfo = ctx.SemanticModel.GetSymbolInfo(elementAccess, ctx.CancellationToken);
+            var property = symbolInfo.Symbol as IPropertySymbol;
+            if (property == null || !property.IsIndexer)
+                return;
+
+            var containing = property.ContainingType;
+            if (containing == null)
+                return;
+
+            if (!DictionaryTypeHelper.IsGenericDictionaryIndexer(property, containing, out var valueType))
+                return;
+
+            var receiverText = elementAccess.Expression.ToString();
+            var keyText = elementAccess.ArgumentList.ToString();
+            var display = receiverText + keyText;
+
+            var descriptor = IsValueTypeForDiagnostic(valueType!)
+                ? Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType
+                : Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType;
+
+            ctx.ReportDiagnostic(Diagnostic.Create(descriptor, elementAccess.GetLocation(), display));
+        }
+
+        private static bool IsAssignmentTarget(ElementAccessExpressionSyntax elementAccess)
+        {
+            // dict[key] = value  -> skip
+            if (elementAccess.Parent is AssignmentExpressionSyntax assignment
+                && assignment.Left == elementAccess
+                && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private static bool IsValueTypeForDiagnostic(ITypeSymbol valueType)
+        {
+            // Unconstrained type parameters: treat as reference-like (safer — null check may apply).
+            if (valueType is ITypeParameterSymbol tp)
+            {
+                if (tp.HasValueTypeConstraint)
+                    return true;
+                return false;
+            }
+            return valueType.IsValueType;
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6000_NonGenericDictionaryIndexerAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6000_NonGenericDictionaryIndexerAnalyzer.cs
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Immutable;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class LuceneDev6000_NonGenericDictionaryIndexerAnalyzer : DiagnosticAnalyzer
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(Descriptors.LuceneDev6000_NonGenericDictionaryIndexer);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeElementAccess, SyntaxKind.ElementAccessExpression);
+        }
+
+        private static void AnalyzeElementAccess(SyntaxNodeAnalysisContext ctx)
+        {
+            var elementAccess = (ElementAccessExpressionSyntax)ctx.Node;
+
+            if (elementAccess.Parent is AssignmentExpressionSyntax assignment
+                && assignment.Left == elementAccess
+                && assignment.IsKind(SyntaxKind.SimpleAssignmentExpression))
+            {
+                return;
+            }
+
+            var symbolInfo = ctx.SemanticModel.GetSymbolInfo(elementAccess, ctx.CancellationToken);
+            var property = symbolInfo.Symbol as IPropertySymbol;
+            if (property == null || !property.IsIndexer)
+                return;
+
+            var containing = property.ContainingType;
+            if (containing == null)
+                return;
+
+            if (!DictionaryTypeHelper.IsNonGenericDictionaryIndexer(property, containing))
+                return;
+
+            var display = elementAccess.Expression.ToString() + elementAccess.ArgumentList.ToString();
+            ctx.ReportDiagnostic(Diagnostic.Create(
+                Descriptors.LuceneDev6000_NonGenericDictionaryIndexer,
+                elementAccess.GetLocation(),
+                display));
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Resources.resx
@@ -219,6 +219,39 @@ under the License.
     <comment>The format-able message the diagnostic displays.</comment>
   </data>
 
+  <!-- 1007: Generic Dictionary indexer with value-type value -->
+  <data name="LuceneDev1007_AnalyzerTitle" xml:space="preserve">
+    <value>Generic Dictionary indexer should not be used to retrieve values (value type)</value>
+  </data>
+  <data name="LuceneDev1007_AnalyzerDescription" xml:space="preserve">
+    <value>Reading values from IDictionary&lt;TKey, TValue&gt; or IReadOnlyDictionary&lt;TKey, TValue&gt; via the indexer throws KeyNotFoundException when the key is missing. Use TryGetValue instead.</value>
+  </data>
+  <data name="LuceneDev1007_AnalyzerMessageFormat" xml:space="preserve">
+    <value>Generic Dictionary indexer '{0}' may throw KeyNotFoundException. Use TryGetValue instead.</value>
+  </data>
+
+  <!-- 1008: Generic Dictionary indexer with reference-type value -->
+  <data name="LuceneDev1008_AnalyzerTitle" xml:space="preserve">
+    <value>Generic Dictionary indexer should not be used to retrieve values (reference type)</value>
+  </data>
+  <data name="LuceneDev1008_AnalyzerDescription" xml:space="preserve">
+    <value>Reading values from IDictionary&lt;TKey, TValue&gt; or IReadOnlyDictionary&lt;TKey, TValue&gt; via the indexer throws KeyNotFoundException when the key is missing. Use TryGetValue instead, and check the out value for null before using it.</value>
+  </data>
+  <data name="LuceneDev1008_AnalyzerMessageFormat" xml:space="preserve">
+    <value>Generic Dictionary indexer '{0}' may throw KeyNotFoundException. Use TryGetValue and check the value for null.</value>
+  </data>
+
+  <!-- 6000: Non-generic IDictionary indexer usage -->
+  <data name="LuceneDev6000_AnalyzerTitle" xml:space="preserve">
+    <value>Non-generic IDictionary indexer may return null</value>
+  </data>
+  <data name="LuceneDev6000_AnalyzerDescription" xml:space="preserve">
+    <value>The non-generic IDictionary indexer returns null for missing keys rather than throwing. Review these usages to ensure the value is checked for null before use.</value>
+  </data>
+  <data name="LuceneDev6000_AnalyzerMessageFormat" xml:space="preserve">
+    <value>Non-generic IDictionary indexer '{0}' may return null for missing keys. Verify the value is checked for null before use.</value>
+  </data>
+
   <!-- 6001: Missing StringComparison -->
   <data name="LuceneDev6001_AnalyzerTitle" xml:space="preserve">
     <value>Missing StringComparison argument</value>

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev1xxx.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev1xxx.cs
@@ -77,5 +77,19 @@ namespace Lucene.Net.CodeAnalysis.Dev.Utility
                 Design,
                 Warning
             );
+
+        public static readonly DiagnosticDescriptor LuceneDev1007_GenericDictionaryIndexerValueType =
+            Diagnostic(
+                "LuceneDev1007",
+                Design,
+                Warning
+            );
+
+        public static readonly DiagnosticDescriptor LuceneDev1008_GenericDictionaryIndexerReferenceType =
+            Diagnostic(
+                "LuceneDev1008",
+                Design,
+                Warning
+            );
     }
 }

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev6xxx.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/Descriptors.LuceneDev6xxx.cs
@@ -29,6 +29,14 @@ namespace Lucene.Net.CodeAnalysis.Dev.Utility
         // and will report RS2002 warnings if it cannot read the DiagnosticDescriptor
         // instance through a field.
 
+        // 6000: Non-generic IDictionary indexer usage — may return null for missing keys
+        public static readonly DiagnosticDescriptor LuceneDev6000_NonGenericDictionaryIndexer =
+            Diagnostic(
+                "LuceneDev6000",
+                Usage,
+                Info
+            );
+
         // 6001: Missing StringComparison argument on String overload
         public static readonly DiagnosticDescriptor LuceneDev6001_MissingStringComparison =
             Diagnostic(

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/DictionaryTypeHelper.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/DictionaryTypeHelper.cs
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using Microsoft.CodeAnalysis;
+
+namespace Lucene.Net.CodeAnalysis.Dev.Utility
+{
+    internal static class DictionaryTypeHelper
+    {
+        private const string GenericIDictionary = "System.Collections.Generic.IDictionary`2";
+        private const string GenericIReadOnlyDictionary = "System.Collections.Generic.IReadOnlyDictionary`2";
+        private const string NonGenericIDictionary = "System.Collections.IDictionary";
+
+        /// <summary>
+        /// Returns true when <paramref name="indexer"/> is the indexer declared by (or implementing)
+        /// <c>IDictionary&lt;TKey, TValue&gt;</c> or <c>IReadOnlyDictionary&lt;TKey, TValue&gt;</c> on a type
+        /// that implements one of those interfaces.
+        /// </summary>
+        public static bool IsGenericDictionaryIndexer(IPropertySymbol indexer, INamedTypeSymbol containingType, out ITypeSymbol? valueType)
+        {
+            valueType = null;
+
+            // Must take a single non-object key parameter. (The IDictionary.this[object] variant is handled elsewhere.)
+            if (indexer.Parameters.Length != 1)
+                return false;
+
+            // If the containing type is itself IDictionary<,> or IReadOnlyDictionary<,>, this is direct.
+            if (containingType.IsGenericType
+                && (MatchesConstructedFrom(containingType, GenericIDictionary)
+                    || MatchesConstructedFrom(containingType, GenericIReadOnlyDictionary)))
+            {
+                valueType = containingType.TypeArguments[1];
+                return true;
+            }
+
+            // Otherwise, containing type must implement one of the generic dictionary interfaces,
+            // and the parameter type must match TKey of an implemented interface.
+            foreach (var iface in containingType.AllInterfaces)
+            {
+                if (!iface.IsGenericType)
+                    continue;
+
+                var matches = MatchesConstructedFrom(iface, GenericIDictionary)
+                              || MatchesConstructedFrom(iface, GenericIReadOnlyDictionary);
+                if (!matches)
+                    continue;
+
+                var tkey = iface.TypeArguments[0];
+                var tvalue = iface.TypeArguments[1];
+
+                if (SymbolEqualityComparer.Default.Equals(indexer.Parameters[0].Type, tkey))
+                {
+                    valueType = tvalue;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="indexer"/> is the non-generic <c>IDictionary</c> indexer
+        /// (takes <see cref="object"/>, returns <see cref="object"/>) declared by or implemented on a type
+        /// that implements <c>System.Collections.IDictionary</c>.
+        /// </summary>
+        public static bool IsNonGenericDictionaryIndexer(IPropertySymbol indexer, INamedTypeSymbol containingType)
+        {
+            if (indexer.Parameters.Length != 1)
+                return false;
+
+            // The non-generic IDictionary indexer returns object and takes object.
+            if (indexer.Parameters[0].Type.SpecialType != SpecialType.System_Object)
+                return false;
+            if (indexer.Type.SpecialType != SpecialType.System_Object)
+                return false;
+
+            if (containingType.ToDisplayString() == NonGenericIDictionary)
+                return true;
+
+            foreach (var iface in containingType.AllInterfaces)
+            {
+                if (iface.ToDisplayString() == NonGenericIDictionary)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static bool MatchesConstructedFrom(INamedTypeSymbol type, string metadataName)
+        {
+            var constructedFrom = type.ConstructedFrom ?? type;
+            return constructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+                       .Equals("global::" + StripArity(metadataName), System.StringComparison.Ordinal)
+                   || MetadataNameEquals(constructedFrom, metadataName);
+        }
+
+        private static string StripArity(string metadataName)
+        {
+            var backtick = metadataName.IndexOf('`');
+            return backtick < 0 ? metadataName : metadataName.Substring(0, backtick);
+        }
+
+        private static bool MetadataNameEquals(INamedTypeSymbol type, string metadataName)
+        {
+            var ns = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+            var full = string.IsNullOrEmpty(ns) ? type.MetadataName : ns + "." + type.MetadataName;
+            return full == metadataName;
+        }
+    }
+}

--- a/src/Lucene.Net.CodeAnalysis.Dev/Utility/DictionaryTypeHelper.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/Utility/DictionaryTypeHelper.cs
@@ -36,7 +36,7 @@ namespace Lucene.Net.CodeAnalysis.Dev.Utility
         {
             valueType = null;
 
-            // Must take a single non-object key parameter. (The IDictionary.this[object] variant is handled elsewhere.)
+            // Must take a single key parameter. (The non-generic IDictionary.this[object] variant is handled elsewhere.)
             if (indexer.Parameters.Length != 1)
                 return false;
 

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.CodeAnalysis.Dev.CodeFixes.LuceneDev1xxx;
+using Lucene.Net.CodeAnalysis.Dev.LuceneDev1xxx;
+using Lucene.Net.CodeAnalysis.Dev.TestUtilities;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+
+namespace Lucene.Net.CodeAnalysis.Dev.CodeFixes
+{
+    public class TestLuceneDev1007_1008_DictionaryIndexerCodeFixProvider
+    {
+        [Test]
+        public async Task TestFix_Return_ReferenceType()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public string M(IDictionary<string, string> dict, string key)
+    {
+        return dict[key];
+    }
+}";
+
+            var fixedCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public string M(IDictionary<string, string> dict, string key)
+    {
+        return dict.TryGetValue(key, out var value) ? value : default;
+    }
+}";
+
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType.MessageFormat)
+                .WithArguments("dict[key]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCodeFixTest(
+                () => new LuceneDev1007_1008_DictionaryIndexerAnalyzer(),
+                () => new LuceneDev1007_1008_DictionaryIndexerCodeFixProvider())
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task TestFix_Return_ValueType()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(IDictionary<string, int> dict, string key)
+    {
+        return dict[key];
+    }
+}";
+
+            var fixedCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(IDictionary<string, int> dict, string key)
+    {
+        return dict.TryGetValue(key, out var value) ? value : default;
+    }
+}";
+
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType.MessageFormat)
+                .WithArguments("dict[key]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCodeFixTest(
+                () => new LuceneDev1007_1008_DictionaryIndexerAnalyzer(),
+                () => new LuceneDev1007_1008_DictionaryIndexerCodeFixProvider())
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+    }
+}

--- a/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.CodeFixes.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerCodeFixProvider.cs
@@ -112,5 +112,58 @@ public class Sample
 
             await test.RunAsync();
         }
+
+        [Test]
+        public async Task TestFix_Return_PicksUniqueLocalName_WhenValueIsInScope()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(IDictionary<string, int> dict, string key)
+    {
+        int value = 42;
+        if (value > 0)
+        {
+            return dict[key];
+        }
+        return value;
+    }
+}";
+
+            var fixedCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(IDictionary<string, int> dict, string key)
+    {
+        int value = 42;
+        if (value > 0)
+        {
+            return dict.TryGetValue(key, out var value1) ? value1 : default;
+        }
+        return value;
+    }
+}";
+
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType.MessageFormat)
+                .WithArguments("dict[key]")
+                .WithLocation("/0/Test0.cs", line: 11, column: 20);
+
+            var test = new InjectableCodeFixTest(
+                () => new LuceneDev1007_1008_DictionaryIndexerAnalyzer(),
+                () => new LuceneDev1007_1008_DictionaryIndexerCodeFixProvider())
+            {
+                TestCode = testCode,
+                FixedCode = fixedCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
     }
 }

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev1xxx/TestLuceneDev1007_1008_DictionaryIndexerAnalyzer.cs
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.CodeAnalysis.Dev.LuceneDev1xxx;
+using Lucene.Net.CodeAnalysis.Dev.TestUtilities;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.CodeAnalysis.Dev.Tests.LuceneDev1xxx
+{
+    [TestFixture]
+    public class TestLuceneDev1007_1008_DictionaryIndexerAnalyzer
+    {
+        [Test]
+        public async Task Detects_IDictionary_ValueType_Reports1007()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(IDictionary<string, int> dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType.MessageFormat)
+                .WithArguments("dict[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Detects_IDictionary_ReferenceType_Reports1008()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public string M(IDictionary<string, string> dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType.MessageFormat)
+                .WithArguments("dict[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Detects_IReadOnlyDictionary_Reports1008()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public string M(IReadOnlyDictionary<string, string> dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1008_GenericDictionaryIndexerReferenceType.MessageFormat)
+                .WithArguments("dict[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Detects_ConcreteDictionary_Reports1007()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(Dictionary<string, int> dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType)
+                .WithSeverity(DiagnosticSeverity.Warning)
+                .WithMessageFormat(Descriptors.LuceneDev1007_GenericDictionaryIndexerValueType.MessageFormat)
+                .WithArguments("dict[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task NoDiagnostic_On_SetterAssignment()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public void M(Dictionary<string, int> dict)
+    {
+        dict[""key""] = 42;
+    }
+}";
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task NoDiagnostic_On_NonDictionaryIndexer()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public int M(List<int> list)
+    {
+        return list[0];
+    }
+}";
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev1007_1008_DictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { }
+            };
+            await test.RunAsync();
+        }
+    }
+}

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6000_NonGenericDictionaryIndexerAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6000_NonGenericDictionaryIndexerAnalyzer.cs
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx;
+using Lucene.Net.CodeAnalysis.Dev.TestUtilities;
+using Lucene.Net.CodeAnalysis.Dev.Utility;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Lucene.Net.CodeAnalysis.Dev.Tests.LuceneDev6xxx
+{
+    [TestFixture]
+    public class TestLuceneDev6000_NonGenericDictionaryIndexerAnalyzer
+    {
+        [Test]
+        public async Task Detects_NonGenericIDictionary_Indexer()
+        {
+            var testCode = @"
+using System.Collections;
+
+public class Sample
+{
+    public object M(IDictionary dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev6000_NonGenericDictionaryIndexer)
+                .WithSeverity(DiagnosticSeverity.Info)
+                .WithMessageFormat(Descriptors.LuceneDev6000_NonGenericDictionaryIndexer.MessageFormat)
+                .WithArguments("dict[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6000_NonGenericDictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Detects_Hashtable_Indexer()
+        {
+            var testCode = @"
+using System.Collections;
+
+public class Sample
+{
+    public object M(Hashtable table)
+    {
+        return table[""key""];
+    }
+}";
+            var expected = new DiagnosticResult(Descriptors.LuceneDev6000_NonGenericDictionaryIndexer)
+                .WithSeverity(DiagnosticSeverity.Info)
+                .WithMessageFormat(Descriptors.LuceneDev6000_NonGenericDictionaryIndexer.MessageFormat)
+                .WithArguments("table[\"key\"]")
+                .WithLocation("/0/Test0.cs", line: 8, column: 16);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6000_NonGenericDictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task NoDiagnostic_On_Generic_Dictionary()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+
+public class Sample
+{
+    public string M(Dictionary<string, string> dict)
+    {
+        return dict[""key""];
+    }
+}";
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6000_NonGenericDictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { }
+            };
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task NoDiagnostic_On_SetterAssignment()
+        {
+            var testCode = @"
+using System.Collections;
+
+public class Sample
+{
+    public void M(IDictionary dict)
+    {
+        dict[""key""] = ""value"";
+    }
+}";
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6000_NonGenericDictionaryIndexerAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { }
+            };
+            await test.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
Adds diagnostics for dictionary indexer usage ported from Java:

- LuceneDev1007 (Design/Warning): generic IDictionary<,> / IReadOnlyDictionary<,>
  indexer read with a value-type value — may throw KeyNotFoundException.
- LuceneDev1008 (Design/Warning): same, but reference-type value; fix should also null-check the result.
- LuceneDev6000 (Usage/Info): non-generic IDictionary indexer read, which returns null for missing keys and should be reviewed.

Includes a code fix for LuceneDev1007/1008 that rewrites the common `return dict[key];` pattern into
`return dict.TryGetValue(key, out var value) ? value : default;`.

Fixes [#1168](https://github.com/apache/lucenenet/issues/1168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)