### PR TITLE
Skip char overloads in LuceneDev6001/6002

### DIFF
--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -118,11 +118,19 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
             var (hasStringComparisonArg, isValidValue, invalidArgLocation, comparisonValueName) =
                 CheckStringComparisonArgument(invocation, semantic, stringComparisonType);
 
+            // The rule only applies to overloads whose first parameter is a string —
+            // overloads like IndexOf(char) / StartsWith(char) have no StringComparison sibling.
+            static bool FirstParameterIsString(IMethodSymbol? m)
+                => m != null && m.Parameters.Length > 0 && m.Parameters[0].Type.SpecialType == SpecialType.System_String;
+
             // If resolved symbol available
             if (methodSymbol != null)
             {
                 // Only apply rule to System.String or J2N.StringBuilderExtensions containing type
                 if (!ContainingTypeIsStringOrJ2N(methodSymbol.ContainingType))
+                    return;
+
+                if (!FirstParameterIsString(methodSymbol))
                     return;
 
                 // If the method has StringComparison parameter in signature
@@ -160,9 +168,9 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
             // Handle ambiguous candidates
             if (candidateSymbols.Length > 0)
             {
-                // Check if any candidate is from String or J2N types
+                // Check if any candidate is from String or J2N types and takes a string first parameter
                 var relevantCandidates = candidateSymbols
-                    .Where(c => ContainingTypeIsStringOrJ2N(c.ContainingType))
+                    .Where(c => ContainingTypeIsStringOrJ2N(c.ContainingType) && FirstParameterIsString(c))
                     .ToImmutableArray();
 
                 if (relevantCandidates.Length == 0)

--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -175,7 +175,7 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
             // Handle ambiguous candidates
             if (candidateSymbols.Length > 0)
             {
-                // Check if any candidate is from String or J2N types and takes a string first parameter
+                // Check if any candidate is from String or J2N types and takes a string value parameter
                 var relevantCandidates = candidateSymbols
                     .Where(c => ContainingTypeIsStringOrJ2N(c.ContainingType) && ValueParameterIsString(c))
                     .ToImmutableArray();

--- a/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/src/Lucene.Net.CodeAnalysis.Dev/LuceneDev6xxx/LuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -118,10 +118,17 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
             var (hasStringComparisonArg, isValidValue, invalidArgLocation, comparisonValueName) =
                 CheckStringComparisonArgument(invocation, semantic, stringComparisonType);
 
-            // The rule only applies to overloads whose first parameter is a string —
+            // The rule only applies to overloads whose value parameter is a string —
             // overloads like IndexOf(char) / StartsWith(char) have no StringComparison sibling.
-            static bool FirstParameterIsString(IMethodSymbol? m)
-                => m != null && m.Parameters.Length > 0 && m.Parameters[0].Type.SpecialType == SpecialType.System_String;
+            // For non-reduced extension method calls (e.g. StringBuilderExtensions.IndexOf(sb, "x")),
+            // Parameters[0] is the receiver, so skip past it.
+            static bool ValueParameterIsString(IMethodSymbol? m)
+            {
+                if (m == null || m.Parameters.Length == 0) return false;
+                int valueIndex = m.IsExtensionMethod && m.ReducedFrom == null ? 1 : 0;
+                return m.Parameters.Length > valueIndex
+                    && m.Parameters[valueIndex].Type.SpecialType == SpecialType.System_String;
+            }
 
             // If resolved symbol available
             if (methodSymbol != null)
@@ -130,7 +137,7 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
                 if (!ContainingTypeIsStringOrJ2N(methodSymbol.ContainingType))
                     return;
 
-                if (!FirstParameterIsString(methodSymbol))
+                if (!ValueParameterIsString(methodSymbol))
                     return;
 
                 // If the method has StringComparison parameter in signature
@@ -170,7 +177,7 @@ namespace Lucene.Net.CodeAnalysis.Dev.LuceneDev6xxx
             {
                 // Check if any candidate is from String or J2N types and takes a string first parameter
                 var relevantCandidates = candidateSymbols
-                    .Where(c => ContainingTypeIsStringOrJ2N(c.ContainingType) && FirstParameterIsString(c))
+                    .Where(c => ContainingTypeIsStringOrJ2N(c.ContainingType) && ValueParameterIsString(c))
                     .ToImmutableArray();
 
                 if (relevantCandidates.Length == 0)

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -79,6 +79,80 @@ public class Sample
         }
 
         [Test]
+        public async Task Skips_IndexOf_CharLiteral()
+        {
+            var testCode = @"
+using System;
+
+public class Sample
+{
+    public void M()
+    {
+        string text = ""Hello"";
+        int index = text.IndexOf('H');
+    }
+}";
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { } // IndexOf(char) has no StringComparison overload; no diagnostic
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Skips_IndexOf_CharVariable()
+        {
+            var testCode = @"
+using System;
+
+public class Sample
+{
+    public void M()
+    {
+        string text = ""Hello"";
+        char c = 'H';
+        int index = text.IndexOf(c);
+    }
+}";
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { } // IndexOf(char) has no StringComparison overload; no diagnostic
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Skips_StartsWith_CharVariable()
+        {
+            var testCode = @"
+using System;
+
+public class Sample
+{
+    public void M()
+    {
+        string text = ""Hello"";
+        char c = 'H';
+        bool starts = text.StartsWith(c);
+    }
+}";
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { } // StartsWith(char) has no StringComparison overload; no diagnostic
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
         public async Task Detects_IndexOf_MissingStringComparison()
         {
             var testCode = @"

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -146,6 +146,7 @@ public class Sample
             var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
             {
                 TestCode = testCode,
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80, // string.StartsWith(char) requires .NET Core 2.0+
                 ExpectedDiagnostics = { } // StartsWith(char) has no StringComparison overload; no diagnostic
             };
 

--- a/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
+++ b/tests/Lucene.Net.CodeAnalysis.Dev.Tests/LuceneDev6xxx/TestLuceneDev6001_6002_StringComparisonAnalyzer.cs
@@ -581,5 +581,82 @@ public class Sample
 
             await test.RunAsync();
         }
+
+        [Test]
+        public async Task Detects_J2NStringBuilderExtensions_ReducedForm_MissingStringComparison()
+        {
+            var testCode = @"
+using System.Text;
+using J2N.Text;
+
+namespace J2N.Text
+{
+    public static class StringBuilderExtensions
+    {
+        public static int IndexOf(this StringBuilder sb, string value) => 0;
+    }
+}
+
+public class Sample
+{
+    public void M()
+    {
+        var sb = new StringBuilder(""hello"");
+        int index = sb.IndexOf(""he"");
+    }
+}";
+
+            var expected = new DiagnosticResult(Descriptors.LuceneDev6001_MissingStringComparison.Id, DiagnosticSeverity.Error)
+                .WithSeverity(DiagnosticSeverity.Error)
+                .WithMessageFormat(Descriptors.LuceneDev6001_MissingStringComparison.MessageFormat)
+                .WithArguments("IndexOf")
+                .WithLocation("/0/Test0.cs", line: 18, column: 24);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
+
+        [Test]
+        public async Task Detects_J2NStringBuilderExtensions_StaticForm_MissingStringComparison()
+        {
+            var testCode = @"
+using System.Text;
+
+namespace J2N.Text
+{
+    public static class StringBuilderExtensions
+    {
+        public static int IndexOf(this StringBuilder sb, string value) => 0;
+    }
+}
+
+public class Sample
+{
+    public void M()
+    {
+        var sb = new StringBuilder(""hello"");
+        int index = J2N.Text.StringBuilderExtensions.IndexOf(sb, ""he"");
+    }
+}";
+
+            var expected = new DiagnosticResult(Descriptors.LuceneDev6001_MissingStringComparison.Id, DiagnosticSeverity.Error)
+                .WithSeverity(DiagnosticSeverity.Error)
+                .WithMessageFormat(Descriptors.LuceneDev6001_MissingStringComparison.MessageFormat)
+                .WithArguments("IndexOf")
+                .WithLocation("/0/Test0.cs", line: 17, column: 54);
+
+            var test = new InjectableCSharpAnalyzerTest(() => new LuceneDev6001_6002_StringComparisonAnalyzer())
+            {
+                TestCode = testCode,
+                ExpectedDiagnostics = { expected }
+            };
+
+            await test.RunAsync();
+        }
     }
 }


### PR DESCRIPTION
The analyzer's literal-only guard only suppressed 6001/6002 when the first argument was a `'x'` char literal or `"x"` single-character string literal. Calls like `text.IndexOf(c)` where `c` is a char variable bound to `string.IndexOf(char)` — which has no StringComparison sibling — falsely tripped 6001 (#1211).

Filter both the resolved-symbol and ambiguous-candidate paths to overloads whose first parameter is `System.String`, so char overloads are excluded from the rule entirely instead of relying on syntactic literal recognition.